### PR TITLE
ci: tolerate artifact storage-quota on upload

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -39,6 +39,7 @@ jobs:
     - name: Upload build artifacts
       if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: actions/upload-artifact@v7
+      continue-on-error: true  # tolerate artifact storage-quota failures
       with:
         name: MinecraftThroughTime
         path: ./Release/


### PR DESCRIPTION
Adds continue-on-error to upload-artifact steps so a full Actions storage quota no longer fails build-passing jobs.